### PR TITLE
[HEAP-22747] target integration aup aap endpoints

### DIFF
--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -201,13 +201,12 @@ export class HeapAction extends Hub.Action {
       if (fieldName !== heapFieldName) {
         const field = allFieldMap[fieldName]
         // Field labels are the original name of the property that has not been sanitized or snake-cased.
-        const fieldLabel = field.label !== undefined ? field.label : fieldName
-        const lookerPropertyName = "Looker " + fieldLabel
+        const propertyName = field.label !== undefined ? field.label : fieldName
         // :TODO: what are and how to handle PivotCells?
         const value = field.is_numeric
           ? +cell.value
           : cell.value.toString().substring(0, 1024)
-        properties[lookerPropertyName] = value
+        properties[propertyName] = value
       }
     }
     return { properties, heapFieldValue }

--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -22,11 +22,15 @@ export type HeapField = HeapFields.Identity | HeapFields.AccountId
 
 interface LookerFieldMap { [fieldName: string]: Hub.Field }
 
+interface PropertyMap { [property: string]: string }
+
 export class HeapAction extends Hub.Action {
   static ADD_USER_PROPERTIES_URL =
     "https://heapanalytics.com/api/add_user_properties"
   static ADD_ACCOUNT_PROPERTIES_URL =
     "https://heapanalytics.com/api/add_account_properties"
+  static HEAP_LIBRARY = "looker"
+
   description = "Add user and account properties to your Heap dataset"
   label = "Heap"
   iconName = "heap/heap.svg"
@@ -71,7 +75,6 @@ export class HeapAction extends Hub.Action {
     let fieldMap: LookerFieldMap = {} as LookerFieldMap
     const heapField = this.resolveHeapField(propertyType)
     const requestUrl = this.resolveApiEndpoint(propertyType)
-    const baseRequestBody = { app_id: request.params.heap_env_id }
     const errors: Error[] = []
 
     await request.streamJsonDetail({
@@ -89,14 +92,16 @@ export class HeapAction extends Hub.Action {
             heapFieldLabel,
             fieldMap,
           )
-          const requestBody = Object.assign({}, baseRequestBody, {
-            [heapField]: heapFieldValue,
+          const requestBody = this.constructBodyForRequest(
+            request.params.heap_env_id!,
+            heapField,
+            heapFieldValue,
             properties,
-          })
+          )
           req.post({
             uri: requestUrl,
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(requestBody),
+            body: requestBody,
           })
         } catch (err) {
           errors.push(err)
@@ -206,6 +211,32 @@ export class HeapAction extends Hub.Action {
       }
     }
     return { properties, heapFieldValue }
+  }
+
+  private constructBodyForRequest(
+    appId: string,
+    heapField: HeapField,
+    heapFieldValue: string,
+    properties: PropertyMap,
+  ): string {
+    const baseRequestBody = { app_id: appId, library: HeapAction.HEAP_LIBRARY };
+    let jsonBody = {}
+    if (heapField === HeapFields.Identity) {
+      jsonBody = {
+        users: [{
+          user_identifier: { email: heapFieldValue },
+          properties,
+        }],
+      }
+    } else if (heapField === HeapFields.AccountId) {
+      jsonBody = {
+        accounts: [{
+          account_id: heapFieldValue,
+          properties,
+        }],
+      }
+    }
+    return JSON.stringify(Object.assign({}, baseRequestBody, jsonBody));
   }
 }
 

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -197,15 +197,15 @@ describe(`${action.constructor.name} unit tests`, () => {
       chai.expect(stubPost).to.have.been.calledTwice
       expectAddUserPropertyRequest(
         {
-          "Looker Property 1": "value1A",
-          "Looker Property 2": "value2A",
+          "Property 1": "value1A",
+          "Property 2": "value2A",
         },
         "testA@heap.io",
       )
       expectAddUserPropertyRequest(
         {
-          "Looker Property 1": "value1B",
-          "Looker Property 2": "value2B",
+          "Property 1": "value1B",
+          "Property 2": "value2B",
         },
         "testB@heap.io",
       )
@@ -244,15 +244,15 @@ describe(`${action.constructor.name} unit tests`, () => {
       chai.expect(stubPost).to.have.been.calledTwice
       expectAddAccountPropertyRequest(
         {
-          "Looker Property 1": "value1A",
-          "Looker Property 2": "value2A",
+          "Property 1": "value1A",
+          "Property 2": "value2A",
         },
         "accountA",
       )
       expectAddAccountPropertyRequest(
         {
-          "Looker Property 1": "value1B",
-          "Looker Property 2": "value2B",
+          "Property 1": "value1B",
+          "Property 2": "value2B",
         },
         "accountB",
       )
@@ -284,8 +284,8 @@ describe(`${action.constructor.name} unit tests`, () => {
 
       expectAddAccountPropertyRequest(
         {
-          "Looker Property 1": 1,
-          "Looker Property 2": "value2",
+          "Property 1": 1,
+          "Property 2": "value2",
         },
         "account",
       )

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -6,8 +6,6 @@ import * as Hub from "../../../src/hub"
 
 import {
   HeapAction,
-  HeapField,
-  HeapFields,
   HeapPropertyType,
   HeapPropertyTypes,
 } from "./heap"
@@ -44,19 +42,42 @@ describe(`${action.constructor.name} unit tests`, () => {
     return request
   }
 
-  const expectRequestSent = (
-    url: string,
+  const expectAddUserPropertyRequest = (
     properties: { [K in string]: string | number },
-    heapTag: HeapField,
-    heapTagValue: string,
+    heapIdentity: string,
   ) => {
     chai.expect(stubPost).to.have.been.calledWith({
-      uri: url,
+      uri: HeapAction.ADD_USER_PROPERTIES_URL,
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         app_id: ENV_ID,
-        [heapTag]: heapTagValue,
-        properties,
+        library: "looker",
+        users: [
+          {
+            user_identifier: { email: heapIdentity },
+            properties,
+          },
+        ],
+      }),
+    })
+  }
+
+  const expectAddAccountPropertyRequest = (
+    properties: { [K in string]: string | number },
+    heapAccountId: string,
+  ) => {
+    chai.expect(stubPost).to.have.been.calledWith({
+      uri: HeapAction.ADD_ACCOUNT_PROPERTIES_URL,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        app_id: ENV_ID,
+        library: "looker",
+        accounts: [
+          {
+            account_id: heapAccountId,
+            properties,
+          },
+        ],
       }),
     })
   }
@@ -174,22 +195,18 @@ describe(`${action.constructor.name} unit tests`, () => {
 
       chai.expect(response.success).to.equal(true)
       chai.expect(stubPost).to.have.been.calledTwice
-      expectRequestSent(
-        HeapAction.ADD_USER_PROPERTIES_URL,
+      expectAddUserPropertyRequest(
         {
           "Looker Property 1": "value1A",
           "Looker Property 2": "value2A",
         },
-        HeapFields.Identity,
         "testA@heap.io",
       )
-      expectRequestSent(
-        HeapAction.ADD_USER_PROPERTIES_URL,
+      expectAddUserPropertyRequest(
         {
           "Looker Property 1": "value1B",
           "Looker Property 2": "value2B",
         },
-        HeapFields.Identity,
         "testB@heap.io",
       )
     })
@@ -225,22 +242,18 @@ describe(`${action.constructor.name} unit tests`, () => {
 
       chai.expect(response.success).to.equal(true)
       chai.expect(stubPost).to.have.been.calledTwice
-      expectRequestSent(
-        HeapAction.ADD_ACCOUNT_PROPERTIES_URL,
+      expectAddAccountPropertyRequest(
         {
           "Looker Property 1": "value1A",
           "Looker Property 2": "value2A",
         },
-        HeapFields.AccountId,
         "accountA",
       )
-      expectRequestSent(
-        HeapAction.ADD_ACCOUNT_PROPERTIES_URL,
+      expectAddAccountPropertyRequest(
         {
           "Looker Property 1": "value1B",
           "Looker Property 2": "value2B",
         },
-        HeapFields.AccountId,
         "accountB",
       )
     })
@@ -269,13 +282,11 @@ describe(`${action.constructor.name} unit tests`, () => {
 
       await action.validateAndExecute(request)
 
-      expectRequestSent(
-        HeapAction.ADD_ACCOUNT_PROPERTIES_URL,
+      expectAddAccountPropertyRequest(
         {
           "Looker Property 1": 1,
           "Looker Property 2": "value2",
         },
-        HeapFields.AccountId,
         "account",
       )
     })


### PR DESCRIPTION
**What** Begin using the integration-specific AUP/AAP requests for the looker action. these endpoints expect a slightly different request payload, but will make sure the properties receive the appropriate metadata when being ingested