### PR TITLE
[HEAP-24964] better error handling

### DIFF
--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -1,5 +1,6 @@
 import * as req from "request-promise-native"
 import * as semver from "semver"
+import * as winston from "winston"
 
 import * as Hub from "../../hub"
 
@@ -165,6 +166,7 @@ export class HeapAction extends Hub.Action {
         errors.length === 0 ? "success" : "failure",
       )
     } catch (err) {
+      winston.warn("Heap track call failed.")
       // swallow internal track call error
     }
 
@@ -172,6 +174,9 @@ export class HeapAction extends Hub.Action {
       return new Hub.ActionResponse({ success: true })
     }
     const errorMsg = errors.map((err) => err.message).join(", ")
+    winston.error(
+      `Heap action for envId ${request.params.heap_env_id} failed with errors: ${errorMsg}`,
+    )
     return new Hub.ActionResponse({ success: false, message: errorMsg })
   }
 


### PR DESCRIPTION
The promise returned from `req.post().promise()` inside `HeapAction.sendRequest` isn't awaited until the very end of the execution so if it throws sooner we get an unhandled promise rejection error