### PR TITLE
[HEAP-28592] improve error in looker

### DIFF
--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -1,5 +1,4 @@
 import * as req from "request-promise-native"
-import * as semver from "semver"
 import * as winston from "winston"
 
 import * as Hub from "../../hub"
@@ -26,6 +25,11 @@ interface LookerFieldMap {
   [fieldName: string]: Hub.Field
 }
 
+interface LogTag {
+  envId: string
+  webhookId: string
+}
+
 interface PropertyMap {
   [property: string]: string
 }
@@ -50,6 +54,7 @@ export class HeapAction extends Hub.Action {
   static LOG_PROGRESS_STEP = 10000
   static DISPLAY_ERROR_COUNT = 250
 
+  emptyHeapEntity = { heapFieldValue: undefined, properties: {} }
   description = "Add user and account properties to your Heap dataset"
   label = "Heap"
   iconName = "heap/heap.svg"
@@ -58,16 +63,9 @@ export class HeapAction extends Hub.Action {
   supportedActionTypes = [Hub.ActionType.Query]
   supportedPropertyTypes = [HeapPropertyTypes.User, HeapPropertyTypes.Account]
   usesStreaming = true
-  supportedFormats = (request: Hub.ActionRequest) => {
-    if (request.lookerVersion && semver.gte(request.lookerVersion, "6.2.0")) {
-      return [Hub.ActionFormat.JsonDetailLiteStream]
-    } else {
-      return [Hub.ActionFormat.JsonDetail]
-    }
-  }
 
   async execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse> {
-    const maybeValidationError = this.validateRequest(request)
+    const maybeValidationError = this.validateParams(request.formParams)
     if (!!maybeValidationError) {
       winston.error(
         `Heap action for envId failed with errors: ${maybeValidationError.message}`,
@@ -82,47 +80,55 @@ export class HeapAction extends Hub.Action {
       .property_type as HeapPropertyType
     const envId = request.formParams.env_id!
     const heapFieldLabel: string = request.formParams.heap_field!
-    let identityField: Hub.Field
+    const webhookId = request.webhookId !== undefined ? request.webhookId : "unknown"
+    const logTag: LogTag = {
+      envId,
+      webhookId,
+    }
+    let identityField: Hub.Field | undefined
 
     let fieldMap: LookerFieldMap = {} as LookerFieldMap
-    const heapField = this.resolveHeapField(propertyType)
-    const requestUrl = this.resolveApiEndpoint(propertyType)
+    const heapField = this.resolveHeapField(propertyType, logTag)
+    const requestUrl = this.resolveApiEndpoint(propertyType, logTag)
     const errors: Error[] = []
+    const requestPromises: Promise<void>[] = []
     let rowsProcessed = 0
     let rowsReceived = 0
     let requestBatch: HeapEntity[] = []
-    const requestPromises: Promise<void>[] = []
 
     await request.streamJsonDetail({
       onFields: (fieldset) => {
-        winston.info(`envId ${envId} fieldset ${JSON.stringify(fieldset)}`)
+        winston.debug(`envId ${envId} fieldset ${JSON.stringify(fieldset)}`, logTag)
         const allFields = Hub.allFields(fieldset)
-        winston.info(`envId ${envId} allFields ${JSON.stringify(allFields)}`)
-        identityField = this.extractHeapFieldByLabel(allFields, heapFieldLabel)
-        winston.info(`envId ${envId} heapFieldName ${identityField} heapFieldLabel ${heapFieldLabel}`)
+        winston.debug(`envId ${envId} allFields ${JSON.stringify(allFields)}`, logTag)
+        identityField = this.extractHeapFieldByLabel(allFields, heapFieldLabel, errors)
+        winston.debug(`envId ${envId} heapFieldName ${identityField} heapFieldLabel ${heapFieldLabel}`, logTag)
         fieldMap = this.extractFieldMap(allFields)
-        winston.info(`envId ${envId} fieldMap ${JSON.stringify(fieldMap)}`)
+        winston.info(`envId ${envId} fieldMap ${JSON.stringify(fieldMap)}`, logTag)
       },
       onRow: (row) => {
         if (rowsReceived % HeapAction.LOG_PROGRESS_STEP === 0) {
-          winston.info(`Example row for envId ${envId} ${JSON.stringify(row)}`)
+          winston.info(`Example row for envId ${envId} ${JSON.stringify(row)}`, logTag)
         }
         rowsReceived += 1
         try {
           const { heapFieldValue, properties } = this.extractPropertiesFromRow(
             row,
-            identityField,
+            identityField!,
             fieldMap,
+            logTag,
           )
           if (!heapFieldValue) {
             return
           }
           rowsProcessed += 1
           requestBatch.push({ heapFieldValue, properties })
-          if (requestBatch.length === HeapAction.ROWS_PER_BATCH) {
+          if (requestBatch.length >= HeapAction.ROWS_PER_BATCH) {
+            const length = requestBatch.length
+            winston.info(`Loading ${length} rows of data to heap`, logTag)
             requestPromises.push(
               this.sendRequest(
-                requestBatch,
+                [...requestBatch],
                 envId,
                 requestUrl,
                 heapField,
@@ -136,25 +142,27 @@ export class HeapAction extends Hub.Action {
                 `Processed ${rowsProcessed} rows in ${
                   rowsProcessed / HeapAction.ROWS_PER_BATCH
                 } batch requests for envId ${envId}.`,
-              )
+              logTag)
             }
           }
         } catch (err) {
-          errors.push(err)
+          errors.push(new Error("Encountered an error onRow, error: " + JSON.stringify(err)))
         }
       },
     })
 
-    if (requestBatch.length > 0) {
-      requestPromises.push(
-        this.sendRequest(requestBatch, envId, requestUrl, heapField, errors),
-      )
-    }
-
     try {
+      const length = requestPromises.length
+      winston.info(`Confirming all ${length} requests are resolved`, logTag)
       await Promise.all(requestPromises)
     } catch (err) {
-      errors.push(err)
+      errors.push(new Error("Encountered an error in execute, error: " + JSON.stringify(err)))
+    }
+
+    if (requestBatch.length > 0) {
+      const length = requestBatch.length
+      winston.info(`Loading the remaining ${length} rows of data to heap`, logTag)
+      await this.sendRequest(requestBatch, envId, requestUrl, heapField, errors)
     }
 
     try {
@@ -165,29 +173,43 @@ export class HeapAction extends Hub.Action {
         errors.length === 0 ? "success" : "failure",
       )
     } catch (err) {
-      winston.warn("Heap track call failed.")
+      winston.warn("Heap track call failed.", logTag)
       // swallow internal track call error
     }
 
     if (errors.length === 0) {
       return new Hub.ActionResponse({ success: true })
+    } else {
+      // limit error message to the first N to avoid returning enormous error messages
+      // (arbitrary limit)
+      const errorsToDisplay = errors.slice(0, HeapAction.DISPLAY_ERROR_COUNT)
+      // tell how many errors there were in total since we're only displaying the first N
+      const errorDesc = `Heap action for envId ${envId} failed with ${errors.length} errors ` +
+        (errors.length > HeapAction.DISPLAY_ERROR_COUNT ? `(displaying first ${HeapAction.DISPLAY_ERROR_COUNT})` : "")
+      winston.error(errorDesc, logTag)
+      // log first N errors
+      errorsToDisplay.forEach((err) => winston.error(`envId ${envId} error: ${err.message}`, logTag))
+      // concat first N errors into a signle errorMsg to return to the looker action hub.
+      const errorMsg = errorsToDisplay.map((err) => err.message).join(", ")
+      return new Hub.ActionResponse({ success: false, message: `${errorDesc} - ${errorMsg}` })
     }
-    // limit error message to the first N to avoid returning enormous error messages
-    // (arbitrary limit)
-    const errorsToDisplay = errors.slice(0, HeapAction.DISPLAY_ERROR_COUNT)
-    // tell how many errors there were in total since we're only displaying the first N
-    const errorDesc = `Heap action for envId ${envId} failed with ${errors.length} errors ` +
-      (errors.length > HeapAction.DISPLAY_ERROR_COUNT ? `(displaying first ${HeapAction.DISPLAY_ERROR_COUNT})` : "")
-    winston.error(errorDesc)
-    // log first N errors
-    errorsToDisplay.forEach((err) => winston.error(`envId ${envId} error: ${err.message}`))
-    // concat first N errors into a signle errorMsg to return to the looker action hub.
-    const errorMsg = errorsToDisplay.map((err) => err.message).join(", ")
-    return new Hub.ActionResponse({ success: false, message: `${errorDesc} - ${errorMsg}` })
   }
 
-  async form() {
+  /*
+  * define the instance properties for the connection to Heap. Form.fields will generate UI in looker.
+  * Here we defined 3 fields, the initial input is stored in request.params, validation is run here
+  *   - a text box for env_id
+  *   - a dropdown for property_type
+  *   - a text box for heap_field
+  */
+  async form(request: Hub.ActionRequest) {
     const form = new Hub.ActionForm()
+    const error = this.validateParams(request.params)
+    if (error) {
+      winston.error(error.message)
+      form.error = error.message
+      return form
+    }
     form.fields = [
       {
         label: "Heap Environment ID",
@@ -216,38 +238,45 @@ export class HeapAction extends Hub.Action {
     return form
   }
 
-  private validateRequest(request: Hub.ActionRequest): Error | undefined {
-    if (!request.formParams.env_id || request.formParams.env_id.match(/\D/g)) {
+  /*
+  * validate the connection configuration, it's an input from the looker admin.
+  * The validation will be run when a field is received (for backward compatibility)
+  * The same validation will be when the connection is initially setup.
+  */
+  private validateParams(formParams: Hub.ParamMap): Error | undefined {
+    if (!formParams.env_id || formParams.env_id.match(/\D/g)) {
       return new Error(
-        `Heap environment ID is invalid: ${request.formParams.env_id}`,
+        `Heap environment ID is invalid: ${formParams.env_id}`,
       )
     }
 
     if (
-      !request.formParams.property_type ||
+      !formParams.property_type ||
       !(this.supportedPropertyTypes as string[]).includes(
-        request.formParams.property_type,
+        formParams.property_type,
       )
     ) {
       return new Error(
-        `Unsupported property type: ${request.formParams.property_type}`,
+        `Unsupported property type: ${formParams.property_type}`,
       )
     }
 
     if (
-      !request.formParams.heap_field ||
-      request.formParams.heap_field.length === 0
+      !formParams.heap_field ||
+      formParams.heap_field.length === 0
     ) {
       return new Error("Column mapping to a Heap field must be provided.")
     }
   }
 
-  private extractHeapFieldByLabel(fields: Hub.Field[], heapFieldLabel: string): Hub.Field {
+  private extractHeapFieldByLabel(fields: Hub.Field[], heapFieldLabel: string, errors: Error[]): Hub.Field | undefined {
     const heapField = fields.find((field) => field.label === heapFieldLabel)
     if (!heapField) {
-      throw new Error(
+      const error = new Error(
         `Heap field (${heapFieldLabel}) is missing in the query result.`,
       )
+      errors.push(error)
+      return undefined
     }
     return heapField
   }
@@ -267,77 +296,112 @@ export class HeapAction extends Hub.Action {
     }, {} as LookerFieldMap)
   }
 
-  private resolveHeapField(propertyType: HeapPropertyType): HeapField {
+  private resolveHeapField(propertyType: HeapPropertyType, logTag: LogTag): HeapField {
     switch (propertyType) {
       case HeapPropertyTypes.Account:
         return HeapFields.AccountId
       case HeapPropertyTypes.User:
         return HeapFields.Identity
       default:
-        throw new Error(`Unsupported property type: ${propertyType}`)
+        const error = new Error(`Unsupported property type: ${propertyType}`)
+        winston.error(error.message, logTag)
+        throw error
     }
   }
 
-  private resolveApiEndpoint(propertyType: HeapPropertyType): string {
+  private resolveApiEndpoint(propertyType: HeapPropertyType, logTag: LogTag): string {
     switch (propertyType) {
       case HeapPropertyTypes.User:
         return HeapAction.ADD_USER_PROPERTIES_URL
       case HeapPropertyTypes.Account:
         return HeapAction.ADD_ACCOUNT_PROPERTIES_URL
       default:
-        throw new Error(`Unsupported property type: ${propertyType}`)
+        const error = new Error(`Unsupported property type: ${propertyType}`)
+        winston.error(error.message, logTag)
+        throw error
     }
   }
 
-  private extractRequiredField(row: Hub.JsonDetail.Row, field: Hub.Field): {key: string, value: any} {
+  private extractRequiredField(
+      row: Hub.JsonDetail.Row,
+      field: Hub.Field,
+    ): {
+      key: string,
+      value: string,
+      success: boolean,
+      error?: string,
+    } {
     // we have observed different behavior based on how the view is created
     // each of the following could potentially be used as keys of the field,
     // so we check each one until we find one that exists.
     const propertiesToCheck = [field.name, field.label_short, field.field_group_label]
     const fieldName = propertiesToCheck.find((f) => !!f && row.hasOwnProperty(f))
     if (fieldName) {
-      return {
+     const value = row[fieldName].value != null ? row[fieldName].value.toString() : ""
+     return {
         key: fieldName,
-        value: row[fieldName].value,
+        value,
+        success: true,
       }
-    }
-    const heapFieldDesc = `${JSON.stringify(propertiesToCheck)}`
-    throw new Error(`Found a row without the ${heapFieldDesc} field. row: ${JSON.stringify(row)}`)
+    } else {
+      const heapFieldDesc = `${JSON.stringify(propertiesToCheck)}`
+      return {
+        key: "",
+        value: "",
+        success: false,
+        error: `Found a row without the ${heapFieldDesc} field or value on the field is empty. ` + 
+          `row: ${JSON.stringify(row)}`,
+      }
+   }
   }
 
+  /*
+  * transform a row to a HeapEntity
+  * if the identity field is not found, skip the value.
+  */
   private extractPropertiesFromRow(
     row: Hub.JsonDetail.Row,
     identityField: Hub.Field,
     allFieldMap: LookerFieldMap,
+    logTag: LogTag,
   ): {
     heapFieldValue: string | undefined;
     properties: PropertyMap;
   } {
     const identityFieldValue = this.extractRequiredField(row, identityField)
-    if (!identityFieldValue.value) {
-      return { heapFieldValue: undefined, properties: {} }
+    if (!identityFieldValue.success) {
+      return this.emptyHeapEntity
     }
-    const heapFieldValue = identityFieldValue.value.toString()
+    try {
+      const heapFieldValue = identityFieldValue.value
 
-    const properties: { [K in string]: string } = {}
-    for (const [fieldName, cell] of Object.entries(row)) {
-      if (fieldName !== identityFieldValue.key) {
-        const field = allFieldMap[fieldName]
-        // Field labels are the original name of the property that has not been sanitized or snake-cased.
-        const propertyName =
-          field.label !== undefined ? field.label : fieldName
-        const cellValue = !!cell.value ? cell.value : cell.filterable_value
-        if (!!cellValue) {
-          const propertyValue = cellValue.toString().substring(0, 1024)
-          // Certain number formats are displayed with commas
-          const sanitizedPropertyValue = field.is_numeric
-            ? propertyValue.replace(/[^0-9\.]+/g, "")
-            : propertyValue
-          properties[propertyName] = sanitizedPropertyValue
+      const properties: { [K in string]: string } = {}
+      for (const [fieldName, cell] of Object.entries(row)) {
+        if (fieldName !== identityFieldValue.key) {
+          const field = allFieldMap[fieldName]
+          // Field labels are the original name of the property that has not been sanitized or snake-cased.
+          const propertyName =
+            field.label !== undefined ? field.label : fieldName
+          const cellValue = !!cell.value ? cell.value : cell.filterable_value
+          if (!!cellValue) {
+            const propertyValue = cellValue.toString().substring(0, 1024)
+            // Certain number formats are displayed with commas
+            const sanitizedPropertyValue = field.is_numeric
+              ? propertyValue.replace(/[^0-9\.]+/g, "")
+              : propertyValue
+            properties[propertyName] = sanitizedPropertyValue
+          }
         }
       }
+      return { properties, heapFieldValue }
+    } catch (err) {
+      winston.error("Encountered an error in heapify, skip the row", {
+        ...logTag,
+        err,
+        row,
+      })
+      return this.emptyHeapEntity
     }
-    return { properties, heapFieldValue }
   }
 
   private constructBodyForRequest(
@@ -386,8 +450,8 @@ export class HeapAction extends Hub.Action {
         })
         .promise()
     } catch (err) {
-      errors.push(err)
-    }
+      errors.push(new Error("Encountered an error in sending request to heap, error: " + JSON.stringify(err)))
+   }
   }
 
   /**

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -5,11 +5,11 @@ import * as sinon from "sinon"
 import * as Hub from "../../../src/hub"
 
 import {
+  HEAP_PROPERTY_TYPES,
   HeapAction,
   HeapField,
   HeapFields,
   HeapPropertyType,
-  HeapPropertyTypes,
 } from "./heap"
 
 const action = new HeapAction()
@@ -122,7 +122,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       const fields = [{ name: "email", label: "Email" }]
       const data = [{ email: { value: "value1" } }]
       const request = buildRequest(
-        HeapPropertyTypes.User,
+        HEAP_PROPERTY_TYPES.User,
         "Email",
         fields,
         data,
@@ -142,7 +142,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       const fields = [{ name: "email", label: "Email" }]
       const data = [{ email: { value: "value1" } }]
       const request = buildRequest(
-        HeapPropertyTypes.User,
+        HEAP_PROPERTY_TYPES.User,
         "Email",
         fields,
         data,
@@ -161,7 +161,7 @@ describe(`${action.constructor.name} unit tests`, () => {
     it("should fail when Heap field column is not provided", async () => {
       const fields = [{ name: "email", label: "Email" }]
       const data = [{ email: { value: "value1" } }]
-      const request = buildRequest(HeapPropertyTypes.User, "", fields, data)
+      const request = buildRequest(HEAP_PROPERTY_TYPES.User, "", fields, data)
 
       const response = await action.validateAndExecute(request)
 
@@ -193,25 +193,25 @@ describe(`${action.constructor.name} unit tests`, () => {
       const fields = [{ name: "name", label: "label" }]
       const data = [{ name: { value: "value1" } }]
       const request = buildRequest(
-        HeapPropertyTypes.User,
+        HEAP_PROPERTY_TYPES.User,
         "Email",
         fields,
         data,
       )
-
-      chai
-        .expect(action.validateAndExecute(request))
-        .to.be.eventually.rejectedWith(
-          "Heap field (Email) is missing in the query result.",
-        )
-      chai.expect(stubPost).to.have.not.been.called
+      const response = await action.validateAndExecute(request)
+      chai.expect(response.success).to.equal(false)
+      chai.expect(response.message).to.contain(
+        "Heap action for envId 1 failed with 1 errors  - Heap field (Email) is missing in the query result."
+      )
+      chai.expect(stubPost).to.have.been.calledOnce
+      expectHeapTrackRequest(HeapFields.Identity, 0, "failure", 0)
     })
 
     it("should skip rows with null heap field", async () => {
       const fields = [{ name: "email", label: "Email" }]
       const data = [{ email: { value: null } }]
       const request = buildRequest(
-        HeapPropertyTypes.User,
+        HEAP_PROPERTY_TYPES.User,
         "Email",
         fields,
         data,
@@ -245,7 +245,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         },
       ]
       const request = buildRequest(
-        HeapPropertyTypes.User,
+        HEAP_PROPERTY_TYPES.User,
         "Email",
         fields,
         data,
@@ -295,7 +295,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         },
       ]
       const request = buildRequest(
-        HeapPropertyTypes.Account,
+        HEAP_PROPERTY_TYPES.Account,
         "Account ID",
         fields,
         data,
@@ -341,7 +341,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       ]
 
       const request = buildRequest(
-        HeapPropertyTypes.Account,
+        HEAP_PROPERTY_TYPES.Account,
         "Account ID",
         fields,
         data,
@@ -374,7 +374,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       }))
 
       const request = buildRequest(
-        HeapPropertyTypes.Account,
+        HEAP_PROPERTY_TYPES.Account,
         "Account ID",
         fields,
         data,
@@ -415,7 +415,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         },
       ]
       const request = buildRequest(
-        HeapPropertyTypes.Account,
+        HEAP_PROPERTY_TYPES.Account,
         "Account ID",
         fields,
         data,

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -347,7 +347,7 @@ describe(`${action.constructor.name} unit tests`, () => {
         data,
       )
 
-      await action.validateAndExecute(request)
+      const response = await action.validateAndExecute(request)
 
       expectAddAccountPropertyRequest([
         {
@@ -358,6 +358,8 @@ describe(`${action.constructor.name} unit tests`, () => {
           heapAccountId: "account",
         },
       ])
+      chai.expect(response.success).to.equal(true)
+      chai.expect(stubPost).to.have.been.calledTwice
     })
 
     it("should correctly batch rows", async () => {

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -200,9 +200,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       )
       const response = await action.validateAndExecute(request)
       chai.expect(response.success).to.equal(false)
-      chai.expect(response.message).to.contain(
-        "Heap field (Email) is missing in the query result."
-      )
+      chai.expect(response.message).to.contain("Heap field (Email) is missing in the query result.")
       chai.expect(stubPost).to.have.been.calledOnce
       expectHeapTrackRequest(HeapFields.Identity, 0, "failure", 0)
     })

--- a/src/actions/heap/test_heap.ts
+++ b/src/actions/heap/test_heap.ts
@@ -201,7 +201,7 @@ describe(`${action.constructor.name} unit tests`, () => {
       const response = await action.validateAndExecute(request)
       chai.expect(response.success).to.equal(false)
       chai.expect(response.message).to.contain(
-        "Heap action for envId 1 failed with 1 errors  - Heap field (Email) is missing in the query result."
+        "Heap field (Email) is missing in the query result."
       )
       chai.expect(stubPost).to.have.been.calledOnce
       expectHeapTrackRequest(HeapFields.Identity, 0, "failure", 0)


### PR DESCRIPTION
- include the form validation in async form, the method is called when the configuration is saved;
- don't throw an error in onFields and onRow, instead, put error to errors. if we want to skip a row, don't push error to errors;
- if errors is not empty, return the failure response
- for every info, error log, try to include envId and webhookId. The webhookId can help us categorize logs for a job.

HEAP-28592