### PR TITLE
[HEAP-28854] add logTag by setting json to true

### DIFF
--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -93,13 +93,13 @@ export class HeapAction extends Hub.Action {
   async execute(request: Hub.ActionRequest): Promise<Hub.ActionResponse> {
     const validationResult = this.validateParams(request.formParams)
     if (!!validationResult) {
-      const { validationError, error } = validationResult;
+      const { validationError, error } = validationResult
       logger.error(
         `Heap action failed with an error: ${error.message}`,
         {
           webhookId: request.webhookId,
           ...request.formParams,
-        }
+        },
       )
       return new Hub.ActionResponse({
         success: false,
@@ -288,13 +288,13 @@ export class HeapAction extends Hub.Action {
   */
   private validateParams(formParams: Hub.ParamMap): {
     validationError: Hub.ValidationError,
-    error: Error
+    error: Error,
   } | undefined {
     if (!formParams.env_id || formParams.env_id.match(/\D/g)) {
-      const message = `Heap environment ID is invalid: ${formParams.env_id}`;
+      const message = `Heap environment ID is invalid: ${formParams.env_id}`
       return {
         validationError: {
-          field: 'env_id',
+          field: "env_id",
           message,
         },
         error: new Error(message),
@@ -310,7 +310,7 @@ export class HeapAction extends Hub.Action {
       const message = `Unsupported property type: ${formParams.property_type}`
       return {
         validationError: {
-          field: 'property_type',
+          field: "property_type",
           message,
         },
         error: new Error(message),
@@ -324,7 +324,7 @@ export class HeapAction extends Hub.Action {
       const message = "Column mapping to a Heap field must be provided."
       return {
         validationError: {
-          field: 'heap_field',
+          field: "heap_field",
           message,
         },
         error: new Error(message),


### PR DESCRIPTION
- according to a [semi-official doc](https://github.com/winstonjs/winston/blob/c9e5f17fe69eaedeb5093c1b520862a837d2893c/docs/transports.md), json means use json instead of a prettier (human friendly) string for meta information in the notification. (default: false)
- copy the same setting from heap/log applied to ECS
- exclude some error from displayErrors
- remove request in form

HEAP-28854