### PR TITLE
add logging to the early return

### DIFF
--- a/src/actions/heap/heap.ts
+++ b/src/actions/heap/heap.ts
@@ -161,6 +161,7 @@ export class HeapAction extends Hub.Action {
               logTag,
             )
             if (!heapFieldValue) {
+              logger.debug("Missing heapFieldValue", row)
               // if heapFieldValue or heapFieldValue is empty, onRow ends early
               return
             }


### PR DESCRIPTION
We're getting `message:Confirming all 0 requests are resolved`

The early return seems to be where this could occur. 

https://heap.slack.com/archives/C036KNG1NPR/p1647300320644039